### PR TITLE
fix invalid commas

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,13 +16,13 @@
     },
     "exclude": [
         "node_modules",
-        "src/types",
+        "src/types"
     ],
     "include": [
         "./src/constants.ts",
         "./src/util.ts",
         "./src/schemaGenerator.ts",
         "./src/toValidation.ts",
-        "./src/index.ts",
+        "./src/index.ts"
     ]
 }


### PR DESCRIPTION
got the following error during `yarn run build` on [Vortex](https://github.com/Nexus-Mods/Vortex)
```
-- started: extensions/modtype-umm/yarn install --mutex file
-- copying files
-- [1/4] Resolving packages...
-- success Already up-to-date.
-- $ generate-validation .
-- {
--   tsConfigFilePath: '/GitHub/Nexus-Mods/Vortex/extensions/modtype-umm/node_modules/ts-v-gen/tsconfig.json'
-- }
xx SyntaxError: Unexpected token ] in JSON at position 498
xx     at JSON.parse (<anonymous>)
```
removing the commas allowed the build to continue.