### PR TITLE
tsconfig: change newline to lf

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
         "strict": true,
         "rootDir": "./src",
         "outDir": "./out",
-        "resolveJsonModule": true
+        "resolveJsonModule": true,
+        "newLine": "lf"
     },
     "exclude": [
         "node_modules",


### PR DESCRIPTION
fixes the issue of building modtype-umm on linux due to botched shebang of the ts-validate.js file

Signed-off-by: Amneesh Singh <natto@weirdnatto.in>